### PR TITLE
update: rename ParentWindow to EmbedWithin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v0.1.0
+## Unreleased
+
+- Rename `ParentWindow` to `EmbedWithin`
+
+## v0.1.0
 
 First release!
 Please feel free to report me at [issue](https://github.com/not-elm/bevy_webview_wry/issues).

--- a/crates/bevy_flurx_api/src/monitor/availables.rs
+++ b/crates/bevy_flurx_api/src/monitor/availables.rs
@@ -6,7 +6,7 @@ use bevy_flurx::action::{once, Action};
 use bevy_flurx::prelude::OmitInput;
 use bevy_flurx_ipc::command;
 use bevy_flurx_ipc::component::WebviewEntity;
-use bevy_webview_wry::prelude::ParentWindow;
+use bevy_webview_wry::prelude::EmbedWithIn;
 
 api_plugin!(
     /// You'll be able to get a describing the monitor infos from a webview.
@@ -28,7 +28,7 @@ fn available_monitors(WebviewEntity(entity): WebviewEntity) -> Action<(), Vec<Mo
 //noinspection DuplicatedCode
 fn available_monitors_system(
     In(entity): In<Entity>,
-    parent: Query<&ParentWindow>,
+    parent: Query<&EmbedWithIn>,
     web_views: NonSend<WinitWindows>,
 ) -> Vec<Monitor> {
     let entity = if let Ok(parent) = parent.get(entity) {

--- a/crates/bevy_flurx_api/src/monitor/availables.rs
+++ b/crates/bevy_flurx_api/src/monitor/availables.rs
@@ -6,7 +6,7 @@ use bevy_flurx::action::{once, Action};
 use bevy_flurx::prelude::OmitInput;
 use bevy_flurx_ipc::command;
 use bevy_flurx_ipc::component::WebviewEntity;
-use bevy_webview_wry::prelude::EmbedWithIn;
+use bevy_webview_wry::prelude::EmbedWithin;
 
 api_plugin!(
     /// You'll be able to get a describing the monitor infos from a webview.
@@ -28,7 +28,7 @@ fn available_monitors(WebviewEntity(entity): WebviewEntity) -> Action<(), Vec<Mo
 //noinspection DuplicatedCode
 fn available_monitors_system(
     In(entity): In<Entity>,
-    parent: Query<&EmbedWithIn>,
+    parent: Query<&EmbedWithin>,
     web_views: NonSend<WinitWindows>,
 ) -> Vec<Monitor> {
     let entity = if let Ok(parent) = parent.get(entity) {

--- a/crates/bevy_flurx_api/src/monitor/current.rs
+++ b/crates/bevy_flurx_api/src/monitor/current.rs
@@ -6,7 +6,7 @@ use bevy_flurx::action::{once, Action};
 use bevy_flurx::prelude::OmitInput;
 use bevy_flurx_ipc::command;
 use bevy_flurx_ipc::component::WebviewEntity;
-use bevy_webview_wry::prelude::EmbedWithIn;
+use bevy_webview_wry::prelude::EmbedWithin;
 
 api_plugin!(
     /// You'll be able to get the current monitor info from a webview.
@@ -28,7 +28,7 @@ fn current_monitor(WebviewEntity(entity): WebviewEntity) -> Action<(), Option<Mo
 //noinspection DuplicatedCode
 fn current_monitor_system(
     In(entity): In<Entity>,
-    parent: Query<&EmbedWithIn>,
+    parent: Query<&EmbedWithin>,
     web_views: NonSend<WinitWindows>,
 ) -> Option<Monitor> {
     let entity = if let Ok(parent) = parent.get(entity) {

--- a/crates/bevy_flurx_api/src/monitor/current.rs
+++ b/crates/bevy_flurx_api/src/monitor/current.rs
@@ -6,7 +6,7 @@ use bevy_flurx::action::{once, Action};
 use bevy_flurx::prelude::OmitInput;
 use bevy_flurx_ipc::command;
 use bevy_flurx_ipc::component::WebviewEntity;
-use bevy_webview_wry::prelude::ParentWindow;
+use bevy_webview_wry::prelude::EmbedWithIn;
 
 api_plugin!(
     /// You'll be able to get the current monitor info from a webview.
@@ -28,7 +28,7 @@ fn current_monitor(WebviewEntity(entity): WebviewEntity) -> Action<(), Option<Mo
 //noinspection DuplicatedCode
 fn current_monitor_system(
     In(entity): In<Entity>,
-    parent: Query<&ParentWindow>,
+    parent: Query<&EmbedWithIn>,
     web_views: NonSend<WinitWindows>,
 ) -> Option<Monitor> {
     let entity = if let Ok(parent) = parent.get(entity) {

--- a/crates/bevy_flurx_api/src/monitor/primary.rs
+++ b/crates/bevy_flurx_api/src/monitor/primary.rs
@@ -6,7 +6,7 @@ use bevy_flurx::action::{once, Action};
 use bevy_flurx::prelude::OmitInput;
 use bevy_flurx_ipc::command;
 use bevy_flurx_ipc::component::WebviewEntity;
-use bevy_webview_wry::prelude::ParentWindow;
+use bevy_webview_wry::prelude::EmbedWithIn;
 
 api_plugin!(
     /// You'll be able to get the current monitor info from a webview.
@@ -28,7 +28,7 @@ fn primary(WebviewEntity(entity): WebviewEntity) -> Action<(), Option<Monitor>> 
 //noinspection DuplicatedCode
 fn primary_system(
     In(entity): In<Entity>,
-    parent: Query<&ParentWindow>,
+    parent: Query<&EmbedWithIn>,
     web_views: NonSend<WinitWindows>,
 ) -> Option<Monitor> {
     let entity = if let Ok(parent) = parent.get(entity) {

--- a/crates/bevy_flurx_api/src/monitor/primary.rs
+++ b/crates/bevy_flurx_api/src/monitor/primary.rs
@@ -6,7 +6,7 @@ use bevy_flurx::action::{once, Action};
 use bevy_flurx::prelude::OmitInput;
 use bevy_flurx_ipc::command;
 use bevy_flurx_ipc::component::WebviewEntity;
-use bevy_webview_wry::prelude::EmbedWithIn;
+use bevy_webview_wry::prelude::EmbedWithin;
 
 api_plugin!(
     /// You'll be able to get the current monitor info from a webview.
@@ -28,7 +28,7 @@ fn primary(WebviewEntity(entity): WebviewEntity) -> Action<(), Option<Monitor>> 
 //noinspection DuplicatedCode
 fn primary_system(
     In(entity): In<Entity>,
-    parent: Query<&EmbedWithIn>,
+    parent: Query<&EmbedWithin>,
     web_views: NonSend<WinitWindows>,
 ) -> Option<Monitor> {
     let entity = if let Ok(parent) = parent.get(entity) {

--- a/crates/bevy_flurx_api/src/web_window.rs
+++ b/crates/bevy_flurx_api/src/web_window.rs
@@ -60,7 +60,7 @@ use bevy::ecs::system::SystemParam;
 use bevy::prelude::{Entity, Mut, Name, NonSend, PluginGroup, Query, Window};
 use bevy::window::WindowWrapper;
 use bevy::winit::WinitWindows;
-use bevy_webview_wry::prelude::EmbedWithIn;
+use bevy_webview_wry::prelude::EmbedWithin;
 
 /// Allows you to use all window plugins.
 ///
@@ -132,7 +132,7 @@ struct WebWinitWindowParams<'w, 's> {
         Entity,
         Option<&'static Name>,
         Option<&'static mut Window>,
-        Option<&'static EmbedWithIn>,
+        Option<&'static EmbedWithin>,
     )>,
     windows: NonSend<'w, WinitWindows>,
 }

--- a/crates/bevy_flurx_api/src/web_window.rs
+++ b/crates/bevy_flurx_api/src/web_window.rs
@@ -60,7 +60,7 @@ use bevy::ecs::system::SystemParam;
 use bevy::prelude::{Entity, Mut, Name, NonSend, PluginGroup, Query, Window};
 use bevy::window::WindowWrapper;
 use bevy::winit::WinitWindows;
-use bevy_webview_wry::prelude::ParentWindow;
+use bevy_webview_wry::prelude::EmbedWithIn;
 
 /// Allows you to use all window plugins.
 ///
@@ -132,7 +132,7 @@ struct WebWinitWindowParams<'w, 's> {
         Entity,
         Option<&'static Name>,
         Option<&'static mut Window>,
-        Option<&'static ParentWindow>,
+        Option<&'static EmbedWithIn>,
     )>,
     windows: NonSend<'w, WinitWindows>,
 }

--- a/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
@@ -7,7 +7,7 @@ use crate::common::plugin::load_webview::ipc::IpcHandlerParams;
 use crate::common::plugin::load_webview::protocol::feed_uri;
 use crate::common::plugin::WryWebViews;
 use crate::common::WebviewInitialized;
-use crate::embedding::bundle::{Bounds, EmbedWithIn};
+use crate::embedding::bundle::{Bounds, EmbedWithin};
 use crate::prelude::Csp;
 use crate::prelude::InitializationScripts;
 use crate::WryLocalRoot;
@@ -69,12 +69,12 @@ fn load_web_views(
             Configs1,
             Configs2,
             ConfigsPlatformSpecific,
-            Option<&EmbedWithIn>,
+            Option<&EmbedWithin>,
             Option<&Bounds>,
         ),
         (
             Without<WebviewInitialized>,
-            Or<(With<Window>, With<EmbedWithIn>)>,
+            Or<(With<Window>, With<EmbedWithin>)>,
         ),
     >,
     ipc_params: IpcHandlerParams,
@@ -210,7 +210,7 @@ fn feed_platform_configs<'a>(
 fn build_webview(
     builder: WebViewBuilder,
     window_entity: Entity,
-    parent_window: Option<&EmbedWithIn>,
+    parent_window: Option<&EmbedWithin>,
     windows: &WinitWindows,
 ) -> Option<wry::Result<WebView>> {
     if let Some(parent_window) = parent_window

--- a/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
@@ -250,7 +250,7 @@ unsafe fn attach_inner_window(
     );
     inner_window.setMovable(false);
     inner_window.makeFirstResponder(Some(webview));
-    inner_window.setIgnoresMouseEvents(true);
+
     let content_rect = application_window.contentRectForFrameRect(application_window.frame());
     inner_window.setFrame_display(content_rect, true);
     inner_window.setHidesOnDeactivate(false);

--- a/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
@@ -13,7 +13,6 @@ use crate::prelude::InitializationScripts;
 use crate::WryLocalRoot;
 use bevy::prelude::{App, Commands, Entity, Name, NonSend, NonSendMut, Or, Plugin, PreUpdate, Query, Res, Window, With, Without};
 use bevy::winit::WinitWindows;
-use objc2_app_kit::NSApplication;
 use rand::distributions::DistString;
 use std::ops::Deref;
 #[cfg(target_os = "macos")]
@@ -268,6 +267,7 @@ unsafe fn attach_inner_window(
 
     inner_window.makeKeyAndOrderFront(None);
 
+    use objc2_app_kit::NSApplication;
     let app = NSApplication::sharedApplication(mtw);
     if objc2_foundation::NSProcessInfo::processInfo().operatingSystemVersion().majorVersion >= 14 {
         NSApplication::activate(&app);

--- a/crates/bevy_webview_wry/src/embedding/bundle.rs
+++ b/crates/bevy_webview_wry/src/embedding/bundle.rs
@@ -28,14 +28,14 @@ mod grip_zone;
 /// ){
 ///     commands.spawn((
 ///         WebviewUri::default(),
-///         EmbedWithIn(window.single()),
+///         EmbedWithin(window.single()),
 ///     ));
 /// }
 #[repr(transparent)]
 #[derive(Component, Copy, Clone, Eq, PartialEq, Reflect)]
 #[require(Bounds, Resizable, GripZone)]
 #[reflect(Component)]
-pub struct EmbedWithIn(pub Entity);
+pub struct EmbedWithin(pub Entity);
 
 /// Whether to allow the webview to be resized.
 ///

--- a/crates/bevy_webview_wry/src/embedding/bundle.rs
+++ b/crates/bevy_webview_wry/src/embedding/bundle.rs
@@ -9,9 +9,7 @@ pub(crate) mod resize;
 mod bounds;
 mod grip_zone;
 
-/// The webview parent window.
-///
-/// Create the webview as a child of an existing [`Window`](bevy::prelude::Window).
+/// Holds the window entity to embed the webview in.
 ///
 /// ## Note
 ///
@@ -30,14 +28,14 @@ mod grip_zone;
 /// ){
 ///     commands.spawn((
 ///         WebviewUri::default(),
-///         ParentWindow(window.single()),
+///         EmbedWithIn(window.single()),
 ///     ));
 /// }
 #[repr(transparent)]
 #[derive(Component, Copy, Clone, Eq, PartialEq, Reflect)]
 #[require(Bounds, Resizable, GripZone)]
 #[reflect(Component)]
-pub struct ParentWindow(pub Entity);
+pub struct EmbedWithIn(pub Entity);
 
 /// Whether to allow the webview to be resized.
 ///

--- a/crates/bevy_webview_wry/src/embedding/plugin.rs
+++ b/crates/bevy_webview_wry/src/embedding/plugin.rs
@@ -1,4 +1,4 @@
-use crate::embedding::bundle::{Bounds, ParentWindow, Resizable};
+use crate::embedding::bundle::{Bounds, EmbedWithIn, Resizable};
 use crate::embedding::plugin::grip_zone::GripZonePlugin;
 use crate::embedding::plugin::resize::ResizePlugin;
 use crate::embedding::CurrentMoving;
@@ -14,7 +14,7 @@ pub(crate) struct AsChildPlugin;
 impl Plugin for AsChildPlugin {
     fn build(&self, app: &mut App) {
         app
-            .register_type::<ParentWindow>()
+            .register_type::<EmbedWithIn>()
             .register_type::<Bounds>()
             .register_type::<Resizable>()
             .register_type::<CurrentMoving>()

--- a/crates/bevy_webview_wry/src/embedding/plugin.rs
+++ b/crates/bevy_webview_wry/src/embedding/plugin.rs
@@ -1,4 +1,4 @@
-use crate::embedding::bundle::{Bounds, EmbedWithIn, Resizable};
+use crate::embedding::bundle::{Bounds, EmbedWithin, Resizable};
 use crate::embedding::plugin::grip_zone::GripZonePlugin;
 use crate::embedding::plugin::resize::ResizePlugin;
 use crate::embedding::CurrentMoving;
@@ -14,7 +14,7 @@ pub(crate) struct AsChildPlugin;
 impl Plugin for AsChildPlugin {
     fn build(&self, app: &mut App) {
         app
-            .register_type::<EmbedWithIn>()
+            .register_type::<EmbedWithin>()
             .register_type::<Bounds>()
             .register_type::<Resizable>()
             .register_type::<CurrentMoving>()

--- a/crates/bevy_webview_wry/src/embedding/plugin/grip_zone.rs
+++ b/crates/bevy_webview_wry/src/embedding/plugin/grip_zone.rs
@@ -1,5 +1,5 @@
 use crate::common::WryWebViews;
-use crate::embedding::bundle::{Bounds, ParentWindow};
+use crate::embedding::bundle::{Bounds, EmbedWithIn};
 use crate::embedding::CurrentMoving;
 use crate::prelude::{DragEntered, GripZone};
 #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -52,7 +52,7 @@ fn resize_grip_zone(
 }
 
 fn move_webview(
-    mut views: Query<(&mut Bounds, &mut CurrentMoving, &ParentWindow), With<CurrentMoving>>,
+    mut views: Query<(&mut Bounds, &mut CurrentMoving, &EmbedWithIn), With<CurrentMoving>>,
     winit_windows: NonSend<WinitWindows>,
     windows: Query<&Window>,
 ) {
@@ -119,7 +119,7 @@ fn grip_zone_grab(
     mut commands: Commands,
     web_views: NonSend<WryWebViews>,
     winit_windows: NonSend<WinitWindows>,
-    views: Query<&ParentWindow>,
+    views: Query<&EmbedWithIn>,
 ) {
     for event in er.read() {
         let mouse = Mouse::new();

--- a/crates/bevy_webview_wry/src/embedding/plugin/grip_zone.rs
+++ b/crates/bevy_webview_wry/src/embedding/plugin/grip_zone.rs
@@ -1,5 +1,5 @@
 use crate::common::WryWebViews;
-use crate::embedding::bundle::{Bounds, EmbedWithIn};
+use crate::embedding::bundle::{Bounds, EmbedWithin};
 use crate::embedding::CurrentMoving;
 use crate::prelude::{DragEntered, GripZone};
 #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -52,7 +52,7 @@ fn resize_grip_zone(
 }
 
 fn move_webview(
-    mut views: Query<(&mut Bounds, &mut CurrentMoving, &EmbedWithIn), With<CurrentMoving>>,
+    mut views: Query<(&mut Bounds, &mut CurrentMoving, &EmbedWithin), With<CurrentMoving>>,
     winit_windows: NonSend<WinitWindows>,
     windows: Query<&Window>,
 ) {
@@ -119,7 +119,7 @@ fn grip_zone_grab(
     mut commands: Commands,
     web_views: NonSend<WryWebViews>,
     winit_windows: NonSend<WinitWindows>,
-    views: Query<&EmbedWithIn>,
+    views: Query<&EmbedWithin>,
 ) {
     for event in er.read() {
         let mouse = Mouse::new();

--- a/crates/bevy_webview_wry/src/embedding/plugin/resize.rs
+++ b/crates/bevy_webview_wry/src/embedding/plugin/resize.rs
@@ -1,6 +1,6 @@
 use crate::common::{WebviewInitialized, WryWebViews};
 use crate::embedding::bundle::resize::ResizeMode;
-use crate::embedding::bundle::{Bounds, EmbedWithIn, Resizable};
+use crate::embedding::bundle::{Bounds, EmbedWithin, Resizable};
 use crate::embedding::CurrentMoving;
 use bevy::input::common_conditions::input_pressed;
 use bevy::math::Vec2;
@@ -29,7 +29,7 @@ impl Plugin for ResizePlugin {
 fn change_mouse_cursor_icon(
     mut commands: Commands,
     mut windows: Query<(Entity, &Window)>,
-    views: Query<(Entity, &EmbedWithIn, &Bounds, &Resizable), Without<CurrentMoving>>,
+    views: Query<(Entity, &EmbedWithin, &Bounds, &Resizable), Without<CurrentMoving>>,
 ) {
     for (entity, parent, bounds, resizable) in views.iter() {
         if !resizable.0 {
@@ -59,7 +59,7 @@ fn change_mouse_cursor_icon(
 }
 
 fn resize_bounds(
-    mut views: Query<(&mut Bounds, &ResizeMode, &EmbedWithIn, &Resizable), Without<CurrentMoving>>,
+    mut views: Query<(&mut Bounds, &ResizeMode, &EmbedWithin, &Resizable), Without<CurrentMoving>>,
     window: Query<&Window>,
 ) {
     for (mut bounds, resize_mode, parent, resizable) in views.iter_mut() {

--- a/crates/bevy_webview_wry/src/embedding/plugin/resize.rs
+++ b/crates/bevy_webview_wry/src/embedding/plugin/resize.rs
@@ -1,6 +1,6 @@
 use crate::common::{WebviewInitialized, WryWebViews};
 use crate::embedding::bundle::resize::ResizeMode;
-use crate::embedding::bundle::{Bounds, ParentWindow, Resizable};
+use crate::embedding::bundle::{Bounds, EmbedWithIn, Resizable};
 use crate::embedding::CurrentMoving;
 use bevy::input::common_conditions::input_pressed;
 use bevy::math::Vec2;
@@ -29,7 +29,7 @@ impl Plugin for ResizePlugin {
 fn change_mouse_cursor_icon(
     mut commands: Commands,
     mut windows: Query<(Entity, &Window)>,
-    views: Query<(Entity, &ParentWindow, &Bounds, &Resizable), Without<CurrentMoving>>,
+    views: Query<(Entity, &EmbedWithIn, &Bounds, &Resizable), Without<CurrentMoving>>,
 ) {
     for (entity, parent, bounds, resizable) in views.iter() {
         if !resizable.0 {
@@ -59,7 +59,7 @@ fn change_mouse_cursor_icon(
 }
 
 fn resize_bounds(
-    mut views: Query<(&mut Bounds, &ResizeMode, &ParentWindow, &Resizable), Without<CurrentMoving>>,
+    mut views: Query<(&mut Bounds, &ResizeMode, &EmbedWithIn, &Resizable), Without<CurrentMoving>>,
     window: Query<&Window>,
 ) {
     for (mut bounds, resize_mode, parent, resizable) in views.iter_mut() {

--- a/examples/wry/embedding.rs
+++ b/examples/wry/embedding.rs
@@ -38,7 +38,7 @@ fn spawn_webview(
     commands.spawn((
         WebviewUri::default(),
         // Specifies the window entity to embed.
-        EmbedWithIn(window.single()),
+        EmbedWithin(window.single()),
         Resizable(true),
         // Grab the top of the webview and allow it to move.
         GripZone(10),
@@ -51,7 +51,7 @@ fn spawn_webview(
 
     commands.spawn((
         WebviewUri::new("https://bevyengine.org/"),
-        EmbedWithIn(window.single()),
+        EmbedWithin(window.single()),
         Bounds {
             position: Vec2::new(700., 100.),
             size: Vec2::new(500., 500.),

--- a/examples/wry/embedding.rs
+++ b/examples/wry/embedding.rs
@@ -38,7 +38,7 @@ fn spawn_webview(
     commands.spawn((
         WebviewUri::default(),
         // Specifies the window entity to embed.
-        ParentWindow(window.single()),
+        EmbedWithIn(window.single()),
         Resizable(true),
         // Grab the top of the webview and allow it to move.
         GripZone(10),
@@ -51,7 +51,7 @@ fn spawn_webview(
 
     commands.spawn((
         WebviewUri::new("https://bevyengine.org/"),
-        ParentWindow(window.single()),
+        EmbedWithIn(window.single()),
         Bounds {
             position: Vec2::new(700., 100.),
             size: Vec2::new(500., 500.),


### PR DESCRIPTION
I have created a crate called `bevy_child_window`, and I have the intention to avoid the name collision with the component name of that crate.