### PR TITLE
fix: redirect handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Release [`bevy_child_window`](https://github.com/not-elm/bevy_child_window) that helps `bevy_webview_wry` to create a
   child window.
 - Add child window example.
+- Fix the bug that a new window is created when a redirect occurs.
 
 ## v0.1.0
 

--- a/crates/bevy_webview_wry/src/common/bundle/handler/on_new_window_request.rs
+++ b/crates/bevy_webview_wry/src/common/bundle/handler/on_new_window_request.rs
@@ -1,28 +1,33 @@
-use bevy::prelude::{Component, Window};
 use crate::common::bundle::handler::PassedUrl;
+use bevy::prelude::{Component, Window};
 
-pub(crate) type BoxedNewWindowRequest = Box<dyn Fn(PassedUrl) -> Option<Window> + Send + Sync + 'static>;
+pub(crate) type BoxedNewWindowRequest = Box<dyn Fn(PassedUrl) -> NewWindowResponse + Send + Sync + 'static>;
 
+#[allow(clippy::large_enum_variant)]
+/// The response to [`OnNewWindowRequest`].
+#[derive(Debug, Clone)]
+pub enum NewWindowResponse {
+    /// Create new window and open url in it.
+    CreateWindow(Window),
+    /// Allow open url in current window.
+    Allow,
+    /// Deny open url.
+    Deny,
+}
 
 /// Specifies the callback to be executed on [`wry::WebViewBuilder::with_new_window_req_handler`].
-///
-/// If [`OnNewWindowRequest::NONE`], the actual callback always returns true.
 #[repr(transparent)]
 #[derive(Component, Default)]
 pub struct OnNewWindowRequest(Option<BoxedNewWindowRequest>);
 
 impl OnNewWindowRequest {
-    /// No callback is specified.
-    /// 
-    /// All new creations of window is permitted.
-    pub const NONE: Self = Self(None);
-
     /// Creates the [`OnNewWindowRequest`].
-    pub fn new(f: impl Fn(PassedUrl) -> Option<Window> + Send + Sync + 'static) -> Self {
+    pub fn new(f: impl Fn(PassedUrl) -> NewWindowResponse + Send + Sync + 'static) -> Self {
         Self(Some(Box::new(f)))
     }
 
-    pub(crate) fn take(&mut self) -> Option<BoxedNewWindowRequest>{
+    #[inline]
+    pub(crate) fn take(&mut self) -> Option<BoxedNewWindowRequest> {
         self.0.take()
     }
 }


### PR DESCRIPTION
The cause was that `with_new_window_req_handler` always returned false, resulting in the behavior of creating a new window.

Make it possible to control the behavior from the following three, and change the default behavior to 2.
1. Create a new window and open a new URL in that.
2. Open the URL in the current window.
3. Do not open the URL.