### PR TITLE
update: support embedding html content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## Unreleased
 
-- Rename `ParentWindow` to `EmbedWithin`
 - Release [`bevy_child_window`](https://github.com/not-elm/bevy_child_window) that helps `bevy_webview_wry` to create a
   child window.
+- Support embedded html content.
 - Add child window example.
-- Fix the bug that a new window is created when a redirect occurs.
+- Fix the bug that a new window is created when a redirect occurs
+
+### Breaking changes
+
+- Rename `ParentWindow` to `EmbedWithin`
+- `WebviewUri` is no longer a component. Instead, `Webview` has been added.
 
 ## v0.1.0
 

--- a/crates/bevy_flurx_api/src/web_window/create.rs
+++ b/crates/bevy_flurx_api/src/web_window/create.rs
@@ -6,7 +6,7 @@ use bevy::window::{Window, WindowResolution};
 use bevy_flurx::action::once;
 use bevy_flurx::prelude::Action;
 use bevy_flurx_ipc::command;
-use bevy_webview_wry::prelude::{AutoPlay, BrowserAcceleratorKeys, HotkeysZoom, Incognito, InitializeFocused, IsOpenDevtools, Theme, UseDevtools, UseHttpsScheme, UserAgent, WebviewUri, WebviewVisible};
+use bevy_webview_wry::prelude::{AutoPlay, BrowserAcceleratorKeys, HotkeysZoom, Incognito, InitializeFocused, IsOpenDevtools, Theme, UseDevtools, UseHttpsScheme, UserAgent, Webview, WebviewUri, WebviewVisible};
 use serde::Deserialize;
 use winit::dpi::PhysicalSize;
 
@@ -79,7 +79,7 @@ fn create(In(args): In<Args>) -> Action<Args> {
                 resolution: to_resolution(args.resolution),
                 ..default()
             },
-            WebviewUri::new(args.url),
+            Webview::Uri(WebviewUri::new(args.url)),
             Name::new(args.identifier),
         ));
         if let Some(auto_play) = args.auto_play {

--- a/crates/bevy_webview_wry/src/common/bundle.rs
+++ b/crates/bevy_webview_wry/src/common/bundle.rs
@@ -17,7 +17,7 @@ pub use theme::Theme;
 pub use use_devtools::UseDevtools;
 pub use user_agent::UserAgent;
 pub use visible::WebviewVisible;
-pub use webview_uri::WebviewUri;
+pub use webview_uri::{Webview, WebviewUri};
 
 mod auto_play;
 mod background;

--- a/crates/bevy_webview_wry/src/common/bundle/webview_uri.rs
+++ b/crates/bevy_webview_wry/src/common/bundle/webview_uri.rs
@@ -7,13 +7,6 @@ use std::path::{Path, PathBuf};
 
 /// Represents the display destination of webview.
 ///
-/// If you want to load a local resource, use custom protocol: `flurx://localhost/<ROOT>/<uri>`.
-///
-/// `<ROOT>` is specified by [`FlurxWryPlugin::local_root`](crate::prelude::WebviewWryPlugin).
-///
-///
-/// Default is `flurx://localhost/`.
-///
 /// ```no_run
 /// use bevy::prelude::*;
 /// use bevy_webview_wry::prelude::*;
@@ -35,7 +28,7 @@ use std::path::{Path, PathBuf};
 ///         .entity(window.single())
 ///         // The actual URL is flurx://localhost/ui/example.html.
 ///         // show assets/ui/example.html
-///         .insert(WebviewUri::relative_local("example.html"));
+///         .insert(Webview::Uri(WebviewUri::relative_local("example.html")));
 /// }
 /// ```
 #[derive(Component, Clone, Debug, Eq, PartialEq, Hash, Reflect, Serialize, Deserialize)]
@@ -62,6 +55,50 @@ use std::path::{Path, PathBuf};
     EventEmitter,
 )]
 #[reflect(Component, Default, Serialize, Deserialize)]
+pub enum Webview {
+    /// Load the webview with the specified remote/local uri.
+    ///
+    /// ## Examples
+    ///
+    /// ```no_run
+    /// use bevy_webview_wry::prelude::{Webview, WebviewUri};
+    /// Webview::Uri(WebviewUri::new("https://bevyengine.org/"));
+    /// Webview::Uri(WebviewUri::relative_local("example.html"));
+    /// ```
+    Uri(WebviewUri),
+
+    /// Load the webview with the specified html content.
+    ///
+    /// ## Examples
+    ///
+    /// ```no_run
+    /// use bevy_webview_wry::prelude::Webview;
+    /// Webview::Html("<html><body><h1>Hello world!</h1></body></html>".to_string());
+    /// ```
+    Html(String),
+}
+
+impl Default for Webview {
+    fn default() -> Self {
+        Webview::Uri(WebviewUri::default())
+    }
+}
+
+impl From<WebviewUri> for Webview {
+    fn from(uri: WebviewUri) -> Self {
+        Webview::Uri(uri)
+    }
+}
+
+/// The Uri that load in the webview.
+///
+/// If you want to load a local resource, use custom protocol: `flurx://localhost/<ROOT>/<uri>`.
+///
+/// `<ROOT>` is specified by [`FlurxWryPlugin::local_root`](crate::prelude::WebviewWryPlugin).
+///
+/// Default is `flurx://localhost/`.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Reflect, Serialize, Deserialize)]
+#[reflect(Default, Serialize, Deserialize)]
 pub struct WebviewUri(pub String);
 
 impl WebviewUri {

--- a/crates/bevy_webview_wry/src/common/plugin/handlers/new_window_request.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/handlers/new_window_request.rs
@@ -1,7 +1,7 @@
 //! Controls the process of creating the new window : [`wry::WebViewBuilder::with_new_window_req_handler`]
 
 use crate::common::plugin::handlers::{RegisterWryEvent, WryEvents};
-use crate::prelude::{PassedUrl, WebviewUri};
+use crate::prelude::{PassedUrl, Webview, WebviewUri};
 use bevy::prelude::{App, Commands, Entity, Event, EventWriter, Plugin, PreUpdate, Reflect, Res, Window};
 
 /// The event indicating that a new window has been opened.
@@ -48,7 +48,7 @@ fn open_new_window(
         let opened_window_entity = commands
             .spawn((
                 request.window,
-                WebviewUri(request.url.0.to_string()),
+                Webview::Uri(WebviewUri(request.url.0.to_string())),
             ))
             .id();
 

--- a/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/load_webview.rs
@@ -1,6 +1,6 @@
 use crate::common::bundle::{
     AutoPlay, Background, BrowserAcceleratorKeys, EnableClipboard, HotkeysZoom, Incognito,
-    InitializeFocused, Theme, UseDevtools, UseHttpsScheme, UserAgent, WebviewUri, WebviewVisible,
+    InitializeFocused, Theme, UseDevtools, UseHttpsScheme, UserAgent, WebviewVisible,
 };
 use crate::common::plugin::handlers::{HandlerQueries, WryEventParams};
 use crate::common::plugin::load_webview::ipc::IpcHandlerParams;
@@ -8,8 +8,8 @@ use crate::common::plugin::load_webview::protocol::feed_uri;
 use crate::common::plugin::WryWebViews;
 use crate::common::WebviewInitialized;
 use crate::embedding::bundle::{Bounds, EmbedWithin};
-use crate::prelude::Csp;
 use crate::prelude::InitializationScripts;
+use crate::prelude::{Csp, Webview};
 use crate::WryLocalRoot;
 use bevy::prelude::{App, Commands, Entity, Name, NonSend, NonSendMut, Or, Plugin, PreUpdate, Query, Res, Window, With, Without};
 use bevy::winit::WinitWindows;
@@ -51,7 +51,7 @@ type Configs2<'a> = (
     &'a InitializeFocused,
     &'a HotkeysZoom,
     &'a UserAgent,
-    &'a WebviewUri,
+    &'a Webview,
     &'a InitializationScripts,
     Option<&'a Csp>,
     Option<&'a Name>,

--- a/crates/bevy_webview_wry/src/common/plugin/load_webview/protocol.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/load_webview/protocol.rs
@@ -4,17 +4,19 @@ use wry::http::header::{CONTENT_SECURITY_POLICY, CONTENT_TYPE};
 use wry::http::Response;
 use wry::{http, WebViewBuilder};
 
-use crate::common::bundle::WebviewUri;
-use crate::prelude::Csp;
+use crate::prelude::{Csp, Webview};
 use crate::WryLocalRoot;
 
 pub fn feed_uri<'a>(
     builder: WebViewBuilder<'a>,
-    uri: &WebviewUri,
+    webview: &Webview,
     local_root: &WryLocalRoot,
     csp: Option<Csp>,
 ) -> WebViewBuilder<'a> {
-    let builder = builder.with_url(uri.0.to_string());
+    let builder = match webview {
+        Webview::Uri(uri) => builder.with_url(&uri.0),
+        Webview::Html(html) => builder.with_html(html),
+    };
     feed_custom_protocol(builder, local_root.clone(), csp)
 }
 

--- a/crates/bevy_webview_wry/src/embedding/bundle.rs
+++ b/crates/bevy_webview_wry/src/embedding/bundle.rs
@@ -27,7 +27,7 @@ mod grip_zone;
 ///     window: Query<Entity, With<PrimaryWindow>>
 /// ){
 ///     commands.spawn((
-///         WebviewUri::default(),
+///         Webview::default(),
 ///         EmbedWithin(window.single()),
 ///     ));
 /// }

--- a/examples/wry/Cargo.toml
+++ b/examples/wry/Cargo.toml
@@ -41,3 +41,7 @@ path = "event_listen.rs"
 [[example]]
 name = "wry_embedding"
 path = "embedding.rs"
+
+[[example]]
+name = "wry_embedding_html"
+path = "embedding_html.rs"

--- a/examples/wry/child_window.rs
+++ b/examples/wry/child_window.rs
@@ -27,7 +27,7 @@ fn spawn_child_window(
             resolution: WindowResolution::new(500., 500.),
             ..default()
         },
-        WebviewUri::new("https://bevyengine.org/"),
+        Webview::Uri(WebviewUri::new("https://bevyengine.org/")),
         ParentWindow(window.single()),
     ));
 }

--- a/examples/wry/embedding.rs
+++ b/examples/wry/embedding.rs
@@ -36,7 +36,7 @@ fn spawn_webview(
     window: Query<Entity, With<PrimaryWindow>>,
 ) {
     commands.spawn((
-        WebviewUri::default(),
+        Webview::Uri(WebviewUri::default()),
         // Specifies the window entity to embed.
         EmbedWithin(window.single()),
         Resizable(true),
@@ -50,7 +50,7 @@ fn spawn_webview(
     ));
 
     commands.spawn((
-        WebviewUri::new("https://bevyengine.org/"),
+        Webview::Uri(WebviewUri::new("https://bevyengine.org/")),
         EmbedWithin(window.single()),
         Bounds {
             position: Vec2::new(700., 100.),

--- a/examples/wry/embedding_html.rs
+++ b/examples/wry/embedding_html.rs
@@ -1,0 +1,26 @@
+//! This example demonstrates how to create a webview with embedding html content.
+
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+use bevy_webview_wry::prelude::*;
+
+fn main() {
+    let mut app = App::new();
+    app
+        .add_plugins((
+            DefaultPlugins,
+            WebviewWryPlugin::default(),
+        ))
+        .add_systems(Startup, insert_webview)
+        .run();
+}
+
+fn insert_webview(
+    mut commands: Commands,
+    window: Query<Entity, With<PrimaryWindow>>,
+) {
+    commands
+        .entity(window.single())
+        .insert(Webview::Html("<html><body><h1>Hello world!</h1></body></html>".to_string()));
+}
+

--- a/examples/wry/event_emit.rs
+++ b/examples/wry/event_emit.rs
@@ -30,7 +30,7 @@ fn spawn_webview(
     window: Query<Entity, With<PrimaryWindow>>,
 ) {
     // Display `assets/ui/event_emit/index.html` within the webview.
-    commands.entity(window.single()).insert(WebviewUri::default());
+    commands.entity(window.single()).insert(Webview::default());
 }
 
 fn emit_event(

--- a/examples/wry/event_listen.rs
+++ b/examples/wry/event_listen.rs
@@ -27,7 +27,7 @@ fn spawn_webview(
     mut commands: Commands,
     window: Query<Entity, With<PrimaryWindow>>,
 ) {
-    commands.entity(window.single()).insert(WebviewUri::default());
+    commands.entity(window.single()).insert(Webview::default());
 }
 
 #[derive(Deserialize, Debug)]

--- a/examples/wry/ipc_command.rs
+++ b/examples/wry/ipc_command.rs
@@ -31,7 +31,7 @@ fn spawn_webview(
     commands.entity(window.single()).insert((
         Num(1),
         // Display `assets/ui/ipc_command/index.html` within the webview
-        WebviewUri::default(),
+        Webview::default(),
         IpcHandlers::new([
             action_command,
             async_command

--- a/examples/wry/simple.rs
+++ b/examples/wry/simple.rs
@@ -22,6 +22,6 @@ fn spawn_webview(
     // Converts the `Window` attached the entity into a webview window. 
     commands
         .entity(window.single())
-        .insert(WebviewUri::new("https://bevyengine.org/"));
+        .insert(Webview::Uri(WebviewUri::new("https://bevyengine.org/")));
 }
 


### PR DESCRIPTION
## Breaking changes

`WebviewUri` is no longer a component. Instead, `Webview` has been added.

## Examples

```rust
use bevy::prelude::*;
use bevy::window::PrimaryWindow;
use bevy_webview_wry::prelude::*;

fn main() {
    let mut app = App::new();
    app
        .add_plugins((
            DefaultPlugins,
            WebviewWryPlugin::default(),
        ))
        .add_systems(Startup, insert_webview)
        .run();
}

fn insert_webview(
    mut commands: Commands,
    window: Query<Entity, With<PrimaryWindow>>,
) {
    commands
        .entity(window.single())
        .insert(Webview::Html("<html><body><h1>Hello world!</h1></body></html>".to_string()));
}
```