### PR TITLE
fix: stop mystery navigation

### DIFF
--- a/crates/bevy_webview_wry/src/common/plugin/handlers.rs
+++ b/crates/bevy_webview_wry/src/common/plugin/handlers.rs
@@ -213,6 +213,11 @@ impl WryEventParams<'_> {
 
         let events = self.navigation_events.clone();
         builder.with_navigation_handler(move |uri| {
+            // FIXME: Not sure why, but sending ipc-command sometimes sends this uri.
+            if uri == "flurx://localhost/?" {
+                return false;
+            }
+            
             let uri = PassedUrl(uri);
             let allow_navigation = on_navigation(uri.clone());
             if allow_navigation {


### PR DESCRIPTION
Not sure why, `flurx://localhost/?` uri may be sent when executing ipc-commands.