### PR TITLE
update: bevy_flurx v0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 
 [workspace.dependencies]
 bevy = { version = "0.16", default-features = false }
-bevy_flurx = { version = "0.11" }
+bevy_flurx = { version = "0.12" }
 bevy_flurx_ipc = { path = "crates/bevy_flurx_ipc", version = "0.4" }
 bevy_flurx_ipc_macro = { path = "crates/bevy_flurx_ipc_macro", version = "0.4" }
 bevy_webview_core = { path = "crates/bevy_webview_core", version = "0.4" }
@@ -34,7 +34,5 @@ redundant_else = "warn"
 match_same_arms = "warn"
 semicolon_if_nothing_returned = "warn"
 
-[workspace.lints.rust]
-missing_docs = "warn"
 
 

--- a/crates/bevy_webview_wry/CHANGELOG.md
+++ b/crates/bevy_webview_wry/CHANGELOG.md
@@ -1,8 +1,17 @@
 ## v0.5.0(Unreleased)
 
+### Breaking Changes
+
+- Reexport `bevy_flurx` from `bevy_webview_wry` crate.
+    - This is a measure to prevent version differences in bevy_flurx.
+
 ### Features
+
+- Update `bevy_flurx` version to `0.12.0`.
 - Support hot-reloading feature flag to enable hot-reloading of webviews.
+
 ### Bugfixes
+
 - Fixed an issue where the embedded webview position would sometimes be incorrect when the window moved.
 
 ## v0.4.0

--- a/crates/bevy_webview_wry/Cargo.toml
+++ b/crates/bevy_webview_wry/Cargo.toml
@@ -25,6 +25,7 @@ bevy = { workspace = true, features = [
     "serialize",
 ] }
 bevy_webview_core = { workspace = true }
+bevy_flurx = { workspace = true }
 bevy_flurx_ipc = { workspace = true }
 bevy_flurx_api = { workspace = true, optional = true, features = ["full"] }
 serde = { workspace = true }
@@ -51,7 +52,6 @@ rfd = { version = "0.15", default-features = false, features = ["gtk3"] }
 
 [dev-dependencies]
 bevy = { version = "0.16", features = ["file_watcher"] }
-bevy_flurx = "0.11"
 bevy_flurx_ipc = { path = "../bevy_flurx_ipc" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bevy_webview_wry/examples/ipc_command.rs
+++ b/crates/bevy_webview_wry/examples/ipc_command.rs
@@ -4,7 +4,6 @@
 
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
-use bevy_flurx::prelude::*;
 use bevy_flurx_ipc::prelude::*;
 use bevy_webview_wry::prelude::*;
 use std::path::PathBuf;

--- a/crates/bevy_webview_wry/src/lib.rs
+++ b/crates/bevy_webview_wry/src/lib.rs
@@ -23,6 +23,11 @@ pub mod api {
     pub use bevy_flurx_api::prelude::*;
 }
 
+/// Provides the [`bevy_flurx`] functionality.
+pub mod flurx {
+    pub use bevy_flurx::prelude::*;
+}
+
 pub mod embedding;
 mod util;
 pub mod webview;
@@ -32,6 +37,7 @@ pub mod prelude {
     pub use crate::{WebviewWryPlugin, embedding::prelude::*, webview::prelude::*};
     #[cfg(feature = "child_window")]
     pub use bevy_child_window::prelude::*;
+    pub use bevy_flurx::prelude::*;
     #[cfg(feature = "api")]
     pub use bevy_flurx_api::prelude::*;
     pub use bevy_flurx_ipc::prelude::*;


### PR DESCRIPTION
I have made bevy_flurx re-exported from bevy_webview_wry.
This is a workaround to avoid crashes caused by Bevy’s TypeId behavior when the version of bevy_flurx used in bevy_webview_wry differs from the one used by the user.